### PR TITLE
feat: model routing enhancements — hy4, local providers, OpenRouter &…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ dist/
 
 # AntigravityTun
 AntigravityTun/
+
+# Local build artifacts (CLI builds with redirected DerivedData)
+.derived_data/

--- a/launcher/Sources/Models/ModelRoutingConfig.swift
+++ b/launcher/Sources/Models/ModelRoutingConfig.swift
@@ -51,6 +51,23 @@ struct ModelRoutingConfig: Codable, Equatable {
     var routingRules: [RoutingRule] = []
     var llmRouter: LLMRouterConfig? = nil
 
+    /// 确保内置服务商（DeepSeek / OfoxAI / CodeBuddy / TokenRouter）及三个本地模型服务（Ollama / vLLM / LM Studio）始终存在。
+    /// 按 id 前缀去重：若用户已配置过，不再重复添加，因此不会覆盖用户在卡片里修改的 endpoint / 启用状态。
+    mutating func ensureBuiltinLocalProviders() {
+        for defaultP in Self.defaultProviders {
+            if !providers.contains(where: { $0.id == defaultP.id }) {
+                providers.append(defaultP)
+            }
+        }
+        for kind in LocalModelServiceKind.allCases {
+            let prefix = "local-\(kind.rawValue)-"
+            let exists = providers.contains { $0.id.hasPrefix(prefix) }
+            if !exists {
+                providers.append(ProviderConfig.localTemplate(kind))
+            }
+        }
+    }
+
     struct ProviderConfig: Codable, Equatable, Identifiable {
         var id: String
         var name: String
@@ -70,6 +87,65 @@ struct ModelRoutingConfig: Codable, Equatable {
             case apiKey = "api_key"
             case models
             case options
+        }
+
+        /// 本地模型服务模板（ollama / vLLM / LM Studio）。
+        /// 三者均暴露 OpenAI 兼容接口，type 统一为 "openai"，默认开启 auto_models
+        /// 自动从 /v1/models 同步模型列表（不写死模型名，避免与本地实际加载不一致）。
+        static func localTemplate(_ kind: LocalModelServiceKind) -> ModelRoutingConfig.ProviderConfig {
+            ModelRoutingConfig.ProviderConfig(
+                id: "local-\(kind.rawValue)-\(UUID().uuidString.prefix(8))",
+                name: kind.displayName,
+                enabled: false,
+                type: "openai",
+                apiEndpoint: kind.defaultEndpoint,
+                apiKey: "",
+                models: [],
+                options: ["auto_models": "true"]
+            )
+        }
+    }
+
+    /// 支持通过 UI 一键添加的本地模型服务类型。
+    /// 均为 OpenAI 兼容，复用 openai provider（http scheme + auto_models）。
+    enum LocalModelServiceKind: String, CaseIterable, Identifiable {
+        case ollama
+        case vllm
+        case lmstudio
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .ollama:   return "Ollama"
+            case .vllm:     return "vLLM"
+            case .lmstudio: return "LM Studio"
+            }
+        }
+
+        /// 默认暴露的本地接入点（OpenAI 兼容 /v1/chat/completions）
+        var defaultEndpoint: String {
+            switch self {
+            case .ollama:   return "http://localhost:11434"
+            case .vllm:     return "http://localhost:8000"
+            case .lmstudio: return "http://localhost:1234"
+            }
+        }
+
+        var website: URL? {
+            switch self {
+            case .ollama:   return URL(string: "https://ollama.com")
+            case .vllm:     return URL(string: "https://docs.vllm.ai")
+            case .lmstudio: return URL(string: "https://lmstudio.ai")
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .ollama:   return "server.rack"
+            case .vllm:     return "cpu"
+            case .lmstudio: return "slider.horizontal.3"
+            }
         }
     }
 
@@ -177,10 +253,62 @@ extension ModelRoutingConfig {
                 "deepseek-v3",
                 "deepseek-r1",
                 "hunyuan-chat",
-                "hy3"
+                "hy3",
+                "hy4-preview"
+                // TODO: 限免版 hy4 模型 ID 待确认后在此追加（例如 hy4-preview-free / hy4-xxx）
             ],
             options: [
                 "api_path": "/v2/chat/completions"
+            ]
+        ),
+        ProviderConfig(
+            id: "tokenrouter",
+            name: "TokenRouter",
+            enabled: false,
+            apiEndpoint: "api.tokenrouter.com",
+            apiKey: "",
+            models: [
+                "anthropic/claude-sonnet-4-6",
+                "anthropic/claude-opus-4-6",
+                "anthropic/claude-3-7-sonnet",
+                "anthropic/claude-3-5-sonnet",
+                "deepseek/deepseek-chat",
+                "deepseek/deepseek-reasoner",
+                "openai/gpt-4o",
+                "openai/gpt-4.5-preview"
+            ],
+            options: [
+                "auto_models": "true"
+            ]
+        ),
+        ProviderConfig(
+            id: "openrouter",
+            name: "OpenRouter",
+            enabled: false,
+            apiEndpoint: "openrouter.ai",
+            apiKey: "",
+            models: [
+                // Top Mainstream Flagship Models
+                "anthropic/claude-3.7-sonnet",
+                "anthropic/claude-3.5-sonnet",
+                "deepseek/deepseek-chat",
+                "deepseek/deepseek-r1",
+                "openai/gpt-4o",
+                "openai/gpt-4.5-preview",
+                "meta-llama/llama-3.3-70b-instruct",
+                "google/gemini-2.5-pro",
+                "google/gemini-2.5-flash",
+                // Top Curated Free Models
+                "liquid/lfm-2.5-2.6b:free",
+                "nvidia/nemotron-3.5-lightning:free",
+                "z-ai/glm-5.2:free",
+                "cohere/north-mini-code:free",
+                "minimax/minimax-m3:free",
+                "thinkingmachines/inkling:free"
+            ],
+            options: [
+                "api_path": "/api/v1/chat/completions",
+                "auto_models": "true"
             ]
         ),
     ]

--- a/launcher/Sources/Services/LaunchService.swift
+++ b/launcher/Sources/Services/LaunchService.swift
@@ -48,7 +48,7 @@ final class LaunchService {
         // P1: proactively ensure a valid combined CA bundle at Launcher startup (silent), so the
         // target app gets a correct bundle on first launch instead of hitting a stale/partial one.
         Task.detached(priority: .utility) { [weak self] in
-            self?.ensureCombinedCABundle(env: nil)
+            _ = self?.ensureCombinedCABundle()
         }
     }
 
@@ -111,8 +111,6 @@ final class LaunchService {
         // breaks TLS verification for all non-MITM traffic (e.g., OAuth to oauth2.googleapis.com).
         let caCertPath = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/antigravity/goproxy_ca.pem").path
-        let combinedCAPath = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config/antigravity/combined_ca.pem").path
         env["NODE_EXTRA_CA_CERTS"] = caCertPath
 
         // Ensure a valid combined CA bundle exists (system roots + goproxy CA) and inject it via
@@ -122,7 +120,9 @@ final class LaunchService {
         // bundle of SYSTEM roots + goproxy CA; if the system roots cannot be obtained we leave
         // SSL_CERT_FILE unset so Go falls back to the OS trust store (strictly safer than a
         // goproxy-only bundle). Detailed steps are logged for diagnostics.
-        ensureCombinedCABundle(env: &env)
+        if let combinedCAPath = ensureCombinedCABundle() {
+            env["SSL_CERT_FILE"] = combinedCAPath
+        }
 
         config.environment = env
         config.createsNewApplicationInstance = true
@@ -153,8 +153,9 @@ final class LaunchService {
 
     /// Ensure a valid combined CA bundle (system root CAs + goproxy CA) exists.
     ///
-    /// When `env` is non-nil, injects `SSL_CERT_FILE` into it (launch path). When nil, the
-    /// method only ensures/regenerates the bundle on disk (silent startup pre-check).
+    /// Returns the path of the valid combined bundle (for the caller to inject as
+    /// `SSL_CERT_FILE`), or `nil` when no valid bundle is available (caller should
+    /// leave `SSL_CERT_FILE` unset so Go falls back to the OS trust store).
     ///
     /// SSL_CERT_FILE REPLACES Go's entire trust store (not additive). If we cannot obtain the
     /// system root CAs we MUST NOT set SSL_CERT_FILE at all — leaving it unset lets Go fall back
@@ -163,7 +164,7 @@ final class LaunchService {
     ///
     /// Every resolution step is logged so field issues can be diagnosed from the Launcher log
     /// (which source supplied the roots, how many certs, and whether the bundle is valid).
-    private func ensureCombinedCABundle(env: inout [String: String]?) {
+    private func ensureCombinedCABundle() -> String? {
         let caCertPath = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/antigravity/goproxy_ca.pem").path
         let combinedCAPath = FileManager.default.homeDirectoryForCurrentUser
@@ -234,10 +235,11 @@ final class LaunchService {
         // Inject SSL_CERT_FILE only when we have a VALID combined bundle. Otherwise leave it unset
         // so Go verifies against the system store.
         if combinedBundleIsValid(combinedCAPath) {
-            env?["SSL_CERT_FILE"] = combinedCAPath
-            log.info("[Launch] SSL_CERT_FILE set -> \(combinedCAPath)")
+            log.info("[Launch] SSL_CERT_FILE -> \(combinedCAPath)")
+            return combinedCAPath
         } else {
             log.warning("[Launch] No valid combined CA bundle; SSL_CERT_FILE left unset (Go uses OS trust store)")
+            return nil
         }
     }
 

--- a/launcher/Sources/Services/ModelListService.swift
+++ b/launcher/Sources/Services/ModelListService.swift
@@ -55,12 +55,115 @@ struct ModelListService {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ModelListError.networkError
         }
-        guard httpResponse.statusCode == 200 else {
-            throw ModelListError.httpError(httpResponse.statusCode)
+        // Special handling for OpenRouter: parse metadata and filter out deprecated/low-quality items
+        if host.contains("openrouter.ai") {
+            let openRouterModels = parseOpenRouterModels(data: data)
+            if !openRouterModels.isEmpty {
+                return openRouterModels
+            }
         }
 
         let modelList = try JSONDecoder().decode(ModelListResponse.self, from: data)
         return modelList.data.map(\.id).sorted()
+    }
+
+    // MARK: - OpenRouter Intelligent Filtering
+
+    private struct OpenRouterModel: Codable {
+        let id: String
+        let name: String?
+        let description: String?
+        let contextLength: Int?
+        let architecture: Architecture?
+        let pricing: Pricing?
+
+        struct Architecture: Codable {
+            let modality: String?
+            let outputModalities: [String]?
+
+            enum CodingKeys: String, CodingKey {
+                case modality
+                case outputModalities = "output_modalities"
+            }
+        }
+
+        struct Pricing: Codable {
+            let prompt: String?
+            let completion: String?
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case description
+            case contextLength = "context_length"
+            case architecture
+            case pricing
+        }
+    }
+
+    private struct OpenRouterModelResponse: Codable {
+        let data: [OpenRouterModel]
+    }
+
+    private func parseOpenRouterModels(data: Data) -> [String] {
+        guard let response = try? JSONDecoder().decode(OpenRouterModelResponse.self, from: data) else {
+            return []
+        }
+
+        // Filter out non-text models, embeddings, moderation/safety guard models
+        let validModels = response.data.filter { model in
+            let mid = model.id.lowercased()
+
+            // Filter out non-text output models
+            if let outputMods = model.architecture?.outputModalities, !outputMods.isEmpty {
+                if !outputMods.contains("text") {
+                    return false
+                }
+            }
+
+            // Filter out non-chat / internal utility models
+            let blacklistedSubstrings = ["guard", "safety", "moderation", "embed", "whisper", "tts", "dall-e", "midjourney"]
+            if blacklistedSubstrings.contains(where: { mid.contains($0) }) {
+                return false
+            }
+
+            return true
+        }
+
+        var freeModels: [String] = []
+        var priorityPaidModels: [String] = []
+        var otherPaidModels: [String] = []
+
+        let priorityPrefixes = [
+            "anthropic/claude-3.7", "anthropic/claude-3.5", "anthropic/claude-sonnet", "anthropic/claude-opus",
+            "deepseek/deepseek-chat", "deepseek/deepseek-r1", "deepseek/deepseek-v3",
+            "openai/gpt-4o", "openai/gpt-4.5", "openai/o1", "openai/o3",
+            "google/gemini-2.5", "google/gemini-2.0", "google/gemini-flash",
+            "meta-llama/llama-3.3", "meta-llama/llama-3.1",
+            "qwen/qwen-2.5", "z-ai/glm-5", "minimax/minimax", "mistralai/mistral-large"
+        ]
+
+        for model in validModels {
+            let mid = model.id
+            let isFree = mid.hasSuffix(":free") ||
+                (model.pricing?.prompt == "0" && model.pricing?.completion == "0")
+
+            if isFree {
+                freeModels.append(mid)
+            } else if priorityPrefixes.contains(where: { mid.lowercased().hasPrefix($0) }) {
+                priorityPaidModels.append(mid)
+            } else {
+                otherPaidModels.append(mid)
+            }
+        }
+
+        freeModels.sort()
+        priorityPaidModels.sort()
+        otherPaidModels.sort()
+
+        // Combine: Priority Flagship -> Curated Free -> Other Models
+        return priorityPaidModels + freeModels + otherPaidModels
     }
 
     /// Probe connectivity by sending a minimal chat completion request.

--- a/launcher/Sources/State/LauncherAppState.swift
+++ b/launcher/Sources/State/LauncherAppState.swift
@@ -407,6 +407,8 @@ final class LauncherAppState: ObservableObject {
     func loadModelRoutingConfigs() {
         do {
             modelRoutingConfig = try modelRoutingService.load()
+            // 确保 Ollama / vLLM / LM Studio 三个本地模型服务卡片始终存在
+            modelRoutingConfig.ensureBuiltinLocalProviders()
             modelRoutingErrorMessage = nil
             hasLoadedModelRoutingConfigs = true
         } catch {

--- a/launcher/Sources/Views/ModelRoutingView.swift
+++ b/launcher/Sources/Views/ModelRoutingView.swift
@@ -6,18 +6,22 @@ struct ModelRoutingView: View {
     @State private var errorMessage: String?
     @State private var isRestarting = false
 
+    @State private var isModelRoutingExpanded = true
+    @State private var isProvidersExpanded = true
+    @State private var isRoutingRulesExpanded = true
+    @State private var isLLMRouterExpanded = true
+
     private var isModelRoutingEnabled: Bool {
         appState.proxyConfigDraft.mitm?.modelRoutingEnabled ?? false
     }
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
+            VStack(alignment: .leading, spacing: 20) {
                 headerSection
 
                 if isModelRoutingEnabled {
-                    providerSection
-                    routingRulesSection
+                    modelRoutingBusinessSection
                     llmRouterSection
                     controlSection
                 } else {
@@ -59,7 +63,7 @@ struct ModelRoutingView: View {
     // MARK: - Header
 
     private var headerSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Image(systemName: "arrow.triangle.branch")
                     .font(.title2)
@@ -75,133 +79,148 @@ struct ModelRoutingView: View {
         }
     }
 
-    // MARK: - Provider Section
+    // MARK: - 模型路由业务配置（接口厂家 + 映射规则 合并为一个大卡片）
 
-    private var providerSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 8) {
-                Image(systemName: "rectangle.stack.badge.person.crop")
-                    .foregroundStyle(.green)
-                Text("接口厂家配置")
-                    .font(.headline)
-            }
-
-            Text("勾选启用的目标厂家，并分别设定对应的 API 接入点（Endpoint）和密钥（API Key）。")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 280), spacing: 16)], spacing: 16) {
-                ForEach($appState.modelRoutingConfig.providers) { $provider in
-                    ProviderCard(provider: $provider)
-                }
-            }
-        }
-        .cardStyle(accent: .green)
-    }
-
-    // MARK: - Routing Rules Section
-
-    private var routingRulesSection: some View {
+    private var modelRoutingBusinessSection: some View {
+        let enabledProvidersCount = appState.modelRoutingConfig.providers.filter(\.enabled).count
+        let totalProvidersCount = appState.modelRoutingConfig.providers.count
+        let rulesCount = appState.modelRoutingConfig.routingRules.count
         let currentRules = appState.modelRoutingConfig.routingRules
 
-        return VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 8) {
-                Image(systemName: "arrow.left.arrow.right")
-                    .foregroundStyle(.orange)
-                Text("模型路由映射规则")
-                    .font(.headline)
-            }
-            Divider()
-
-            Text("配置需要转译的源模型，选择目标服务商和模型。规则存在即生效，删除即停止映射。")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            // Header labels
-            HStack(spacing: 8) {
-                Text("源模型匹配名称")
-                    .font(.caption)
-                    .bold()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 140, alignment: .leading)
-                Spacer().frame(width: 20)
-                Text("目标服务商")
-                    .font(.caption)
-                    .bold()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 130, alignment: .leading)
-                Text("映射目标模型")
-                    .font(.caption)
-                    .bold()
-                    .foregroundStyle(.secondary)
-                    .frame(width: 170, alignment: .leading)
-                Spacer().frame(width: 24)
-            }
-            .padding(.horizontal, 8)
-
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach($appState.modelRoutingConfig.routingRules) { $rule in
-                    let ruleID = $rule.wrappedValue.id
-                    RoutingRuleRow(
-                        rule: $rule,
-                        allProviders: appState.modelRoutingConfig.providers,
-                        onDelete: {
-                            appState.modelRoutingConfig.routingRules.removeAll { $0.id == ruleID }
+        return CollapsibleCard(
+            icon: "arrow.triangle.2.circlepath",
+            accentColor: .green,
+            title: "模型路由配置",
+            subtitle: "配置第三方 API 接口厂家及源模型至目标模型的映射规则",
+            badgeText: "\(enabledProvidersCount)/\(totalProvidersCount) 厂家 · \(rulesCount) 规则",
+            isExpanded: $isModelRoutingExpanded
+        ) {
+            VStack(alignment: .leading, spacing: 18) {
+                // 子区 1：接口厂家配置
+                SubCollapsibleSection(
+                    icon: "rectangle.stack.badge.person.crop",
+                    accentColor: .green,
+                    title: "接口厂家配置",
+                    description: "勾选启用的目标厂家，并分别设定对应的 API 接入点（Endpoint）和密钥（API Key）。超过两行可向下滚动查看更多。",
+                    badgeText: "\(enabledProvidersCount) 启用",
+                    isExpanded: $isProvidersExpanded
+                ) {
+                    ScrollView(.vertical, showsIndicators: true) {
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 280), spacing: 14)], spacing: 14) {
+                            ForEach($appState.modelRoutingConfig.providers) { $provider in
+                                ProviderCard(provider: $provider)
+                            }
                         }
-                    )
-                    if ruleID != currentRules.last?.id {
-                        Divider().opacity(0.5)
+                        .padding(.vertical, 4)
+                        .padding(.horizontal, 2)
                     }
+                    .frame(maxHeight: 520)
+                    .padding(.top, 4)
                 }
 
-                Button(action: {
-                    let newRule = ModelRoutingConfig.RoutingRule(
-                        sourceModelPattern: "",
-                        sourceDisplayName: "新规则",
-                        sourceType: "google",
-                        targetProviderID: nil,
-                        targetModel: nil,
-                        enabled: true
-                    )
-                    appState.modelRoutingConfig.routingRules.append(newRule)
-                }) {
-                    HStack(spacing: 6) {
-                        Spacer()
-                        Image(systemName: "plus.circle")
-                        Text("添加规则")
-                        Spacer()
+                Divider()
+                    .opacity(0.5)
+
+                // 子区 2：模型路由映射规则
+                SubCollapsibleSection(
+                    icon: "arrow.left.arrow.right",
+                    accentColor: .orange,
+                    title: "模型路由映射规则",
+                    description: "配置需要转译的源模型，选择目标服务商和模型。规则存在即生效，删除即停止映射。",
+                    badgeText: "\(rulesCount) 条规则",
+                    isExpanded: $isRoutingRulesExpanded
+                ) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        // Header labels
+                        HStack(spacing: 8) {
+                            Text("源模型匹配名称")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 140, alignment: .leading)
+                            Spacer().frame(width: 20)
+                            Text("目标服务商")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 130, alignment: .leading)
+                            Text("映射目标模型")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 170, alignment: .leading)
+                            Spacer().frame(width: 24)
+                        }
+                        .padding(.horizontal, 8)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach($appState.modelRoutingConfig.routingRules) { $rule in
+                                let ruleID = $rule.wrappedValue.id
+                                RoutingRuleRow(
+                                    rule: $rule,
+                                    allProviders: appState.modelRoutingConfig.providers,
+                                    onDelete: {
+                                        appState.modelRoutingConfig.routingRules.removeAll { $0.id == ruleID }
+                                    }
+                                )
+                                if ruleID != currentRules.last?.id {
+                                    Divider().opacity(0.4)
+                                }
+                            }
+
+                            Button(action: {
+                                let newRule = ModelRoutingConfig.RoutingRule(
+                                    sourceModelPattern: "",
+                                    sourceDisplayName: "新规则",
+                                    sourceType: "google",
+                                    targetProviderID: nil,
+                                    targetModel: nil,
+                                    enabled: true
+                                )
+                                appState.modelRoutingConfig.routingRules.append(newRule)
+                            }) {
+                                HStack(spacing: 6) {
+                                    Spacer()
+                                    Image(systemName: "plus.circle")
+                                    Text("添加规则")
+                                    Spacer()
+                                }
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [5, 4]))
+                                        .foregroundStyle(.secondary.opacity(0.5))
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.top, 4)
+                        }
+                        .innerPanelStyle()
                     }
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(style: StrokeStyle(lineWidth: 1, dash: [5, 4]))
-                            .foregroundStyle(.secondary.opacity(0.5))
-                    )
+                    .padding(.top, 4)
                 }
-                .buttonStyle(.plain)
-                .padding(.top, 4)
             }
-            .innerPanelStyle()
         }
-        .padding(20)
-        .cardStyle(accent: .orange)
     }
 
     // MARK: - LLMRouter Section
 
     private var llmRouterSection: some View {
         let hasLLMRouterRules = appState.modelRoutingConfig.routingRules.contains { $0.targetProviderID == LLMRouterProviderID }
+        let isRouterEnabled = appState.modelRoutingConfig.llmRouter?.enabled ?? false
+        let ruleCount = appState.modelRoutingConfig.llmRouter?.rules.count ?? 0
 
-        return VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 8) {
-                Image(systemName: "shuffle")
-                    .foregroundStyle(.purple)
-                Text("LLM Router（关键词路由）")
-                    .font(.headline)
-                Spacer()
+        return CollapsibleCard(
+            icon: "shuffle",
+            accentColor: .purple,
+            title: "LLM Router（关键词路由）",
+            subtitle: "根据请求 Prompt 关键词，智能分流路由至不同目标模型",
+            badgeText: isRouterEnabled ? "已启用 · \(ruleCount) 规则" : "未开启",
+            isExpanded: $isLLMRouterExpanded,
+            headerTrailing: {
                 Toggle("", isOn: Binding(
                     get: { appState.modelRoutingConfig.llmRouter?.enabled ?? false },
                     set: { isOn in
@@ -218,157 +237,186 @@ struct ModelRoutingView: View {
                 .toggleStyle(.switch)
                 .labelsHidden()
             }
-            Divider()
-
-            if !hasLLMRouterRules {
-                Text("在上方「模型路由映射规则」中将目标服务商选择为「LLM Router」后，请求将进入关键词路由子系统。")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else if appState.modelRoutingConfig.llmRouter == nil || !appState.modelRoutingConfig.llmRouter!.enabled {
-                Text("已有规则映射到 LLM Router，但未开启此功能。开启后将根据关键词匹配路由到不同模型。")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            } else {
-                Text("根据请求内容中的关键词，自动路由到不同的目标模型。未命中关键词时使用默认模型。")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            if appState.modelRoutingConfig.llmRouter?.enabled == true {
-                // Default model
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("默认模型（未命中关键词时使用）")
-                        .font(.caption)
-                        .bold()
-                        .foregroundStyle(.secondary)
-
+        ) {
+            VStack(alignment: .leading, spacing: 16) {
+                if !hasLLMRouterRules {
                     HStack(spacing: 8) {
-                        Picker("默认厂家", selection: Binding(
-                            get: { appState.modelRoutingConfig.llmRouter?.defaultProviderID ?? "" },
-                            set: { newID in
-                                appState.modelRoutingConfig.llmRouter?.defaultProviderID = newID
-                                if let p = appState.modelRoutingConfig.providers.first(where: { $0.id == newID && $0.enabled }),
-                                   !p.models.isEmpty {
-                                    appState.modelRoutingConfig.llmRouter?.defaultModel = p.models[0]
-                                } else {
-                                    appState.modelRoutingConfig.llmRouter?.defaultModel = ""
-                                }
-                            }
-                        )) {
-                            Text("选择厂家").tag("")
-                            ForEach(appState.modelRoutingConfig.providers.filter(\.enabled)) { p in
-                                Text(p.name).tag(p.id)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: 150)
+                        Image(systemName: "info.circle")
+                            .foregroundStyle(.secondary)
+                        Text("在上方「模型路由映射规则」中将目标服务商选择为「LLM Router」后，请求将进入关键词路由子系统。")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(10)
+                    .background(Color.secondary.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else if !isRouterEnabled {
+                    HStack(spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+                        Text("已有规则映射到 LLM Router，但尚未开启此功能开关。开启后将按关键词分流。")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                    .padding(10)
+                    .background(Color.orange.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                } else {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.purple)
+                        Text("根据请求 Prompt 中的关键词自动匹配并路由至目标模型；未命中时使用下方默认模型。")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
 
-                        let defaultPID = appState.modelRoutingConfig.llmRouter?.defaultProviderID ?? ""
-                        if let provider = appState.modelRoutingConfig.providers.first(where: { $0.id == defaultPID && $0.enabled }) {
-                            Picker("默认模型", selection: Binding(
-                                get: { appState.modelRoutingConfig.llmRouter?.defaultModel ?? "" },
-                                set: { appState.modelRoutingConfig.llmRouter?.defaultModel = $0 }
+                if isRouterEnabled {
+                    // Default model section
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("默认模型（未命中关键词时使用）")
+                            .font(.caption)
+                            .bold()
+                            .foregroundStyle(.secondary)
+
+                        HStack(spacing: 12) {
+                            Picker("默认厂家", selection: Binding(
+                                get: { appState.modelRoutingConfig.llmRouter?.defaultProviderID ?? "" },
+                                set: { newID in
+                                    appState.modelRoutingConfig.llmRouter?.defaultProviderID = newID
+                                    if let p = appState.modelRoutingConfig.providers.first(where: { $0.id == newID && $0.enabled }),
+                                       !p.models.isEmpty {
+                                        appState.modelRoutingConfig.llmRouter?.defaultModel = p.models[0]
+                                    } else {
+                                        appState.modelRoutingConfig.llmRouter?.defaultModel = ""
+                                    }
+                                }
                             )) {
-                                Text("选择模型").tag("")
-                                ForEach(provider.models, id: \.self) { m in
-                                    Text(m).tag(m)
+                                Text("选择厂家").tag("")
+                                ForEach(appState.modelRoutingConfig.providers.filter(\.enabled)) { p in
+                                    Text(p.name).tag(p.id)
                                 }
                             }
                             .labelsHidden()
-                            .frame(width: 200)
-                        } else {
-                            Spacer().frame(width: 200)
-                        }
-                    }
-                }
+                            .frame(width: 160)
 
-                Divider()
-
-                // Keyword rules
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("关键词路由规则")
-                        .font(.caption)
-                        .bold()
-                        .foregroundStyle(.secondary)
-
-                    // Header
-                    HStack(spacing: 8) {
-                        Text("关键词（逗号分隔）")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 200, alignment: .leading)
-                        Text("匹配模式")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 90, alignment: .leading)
-                        Text("目标厂家")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 120, alignment: .leading)
-                        Text("目标模型")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 160, alignment: .leading)
-                        Spacer().frame(width: 24)
-                    }
-                    .padding(.horizontal, 4)
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        let rulesBinding = Binding<[ModelRoutingConfig.LLMRouterRule]>(
-                            get: { appState.modelRoutingConfig.llmRouter?.rules ?? [] },
-                            set: { appState.modelRoutingConfig.llmRouter?.rules = $0 }
-                        )
-                        let currentRules = appState.modelRoutingConfig.llmRouter?.rules ?? []
-                        ForEach(rulesBinding) { $rule in
-                            let ruleID = $rule.wrappedValue.id
-                            LLMRouterRuleRow(
-                                rule: $rule,
-                                allProviders: appState.modelRoutingConfig.providers,
-                                onDelete: {
-                                    appState.modelRoutingConfig.llmRouter?.rules.removeAll { $0.id == ruleID }
+                            let defaultPID = appState.modelRoutingConfig.llmRouter?.defaultProviderID ?? ""
+                            if let provider = appState.modelRoutingConfig.providers.first(where: { $0.id == defaultPID && $0.enabled }) {
+                                Picker("默认模型", selection: Binding(
+                                    get: { appState.modelRoutingConfig.llmRouter?.defaultModel ?? "" },
+                                    set: { appState.modelRoutingConfig.llmRouter?.defaultModel = $0 }
+                                )) {
+                                    Text("选择模型").tag("")
+                                    ForEach(provider.models, id: \.self) { m in
+                                        Text(m).tag(m)
+                                    }
                                 }
-                            )
-                            if ruleID != currentRules.last?.id {
-                                Divider().opacity(0.3)
+                                .labelsHidden()
+                                .frame(width: 200)
+                            } else {
+                                Spacer().frame(width: 200)
                             }
                         }
-
-                        Button(action: {
-                            appState.modelRoutingConfig.llmRouter?.rules.append(
-                                ModelRoutingConfig.LLMRouterRule()
-                            )
-                        }) {
-                            HStack(spacing: 6) {
-                                Spacer()
-                                Image(systemName: "plus.circle")
-                                Text("添加关键词规则")
-                                Spacer()
-                            }
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 8)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [5, 4]))
-                                    .foregroundStyle(.secondary.opacity(0.5))
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.top, 4)
+                        .padding(10)
+                        .background(Color(nsColor: .textBackgroundColor))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color(nsColor: .separatorColor).opacity(0.4), lineWidth: 1)
+                        )
                     }
-                    .innerPanelStyle()
+
+                    Divider()
+                        .opacity(0.5)
+
+                    // Keyword rules
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("关键词路由规则")
+                            .font(.caption)
+                            .bold()
+                            .foregroundStyle(.secondary)
+
+                        // Header
+                        HStack(spacing: 8) {
+                            Text("关键词（逗号分隔）")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 200, alignment: .leading)
+                            Text("匹配模式")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 90, alignment: .leading)
+                            Text("目标厂家")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 120, alignment: .leading)
+                            Text("目标模型")
+                                .font(.caption)
+                                .bold()
+                                .foregroundStyle(.secondary)
+                                .frame(width: 160, alignment: .leading)
+                            Spacer().frame(width: 24)
+                        }
+                        .padding(.horizontal, 8)
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            let rulesBinding = Binding<[ModelRoutingConfig.LLMRouterRule]>(
+                                get: { appState.modelRoutingConfig.llmRouter?.rules ?? [] },
+                                set: { appState.modelRoutingConfig.llmRouter?.rules = $0 }
+                            )
+                            let currentRules = appState.modelRoutingConfig.llmRouter?.rules ?? []
+                            ForEach(rulesBinding) { $rule in
+                                let ruleID = $rule.wrappedValue.id
+                                LLMRouterRuleRow(
+                                    rule: $rule,
+                                    allProviders: appState.modelRoutingConfig.providers,
+                                    onDelete: {
+                                        appState.modelRoutingConfig.llmRouter?.rules.removeAll { $0.id == ruleID }
+                                    }
+                                )
+                                if ruleID != currentRules.last?.id {
+                                    Divider().opacity(0.3)
+                                }
+                            }
+
+                            Button(action: {
+                                appState.modelRoutingConfig.llmRouter?.rules.append(
+                                    ModelRoutingConfig.LLMRouterRule()
+                                )
+                            }) {
+                                HStack(spacing: 6) {
+                                    Spacer()
+                                    Image(systemName: "plus.circle")
+                                    Text("添加关键词规则")
+                                    Spacer()
+                                }
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(style: StrokeStyle(lineWidth: 1, dash: [5, 4]))
+                                        .foregroundStyle(.secondary.opacity(0.5))
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.top, 4)
+                        }
+                        .innerPanelStyle()
+                    }
                 }
             }
         }
-        .padding(20)
-        .cardStyle(accent: .purple)
     }
 
     // MARK: - Control Section
 
     private var controlSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 12) {
                 Button(action: {
                     appState.modelRoutingConfig = .default
@@ -394,18 +442,26 @@ struct ModelRoutingView: View {
                 Spacer()
 
                 if let message = statusMessage {
-                    Text(message)
-                        .font(.subheadline)
-                        .foregroundStyle(.green)
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                        Text(message)
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.green)
                 }
                 if let error = errorMessage {
-                    Text(error)
-                        .font(.subheadline)
-                        .foregroundStyle(.red)
+                    HStack(spacing: 4) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                        Text(error)
+                    }
+                    .font(.subheadline)
+                    .foregroundStyle(.red)
                 }
             }
 
             Divider()
+                .opacity(0.5)
+
             HStack(spacing: 8) {
                 Image(systemName: "doc.text.fill")
                     .foregroundStyle(.secondary)
@@ -415,8 +471,17 @@ struct ModelRoutingView: View {
                     .textSelection(.enabled)
             }
         }
-        .padding(20)
-        .cardStyle(accent: nil)
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .shadow(color: Color.black.opacity(0.04), radius: 3, x: 0, y: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(nsColor: .separatorColor).opacity(0.5), lineWidth: 1)
+        )
     }
 
     // MARK: - Helpers
@@ -454,6 +519,206 @@ struct ModelRoutingView: View {
     }
 }
 
+// MARK: - Collapsible Card
+
+struct CollapsibleCard<HeaderTrailing: View, Content: View>: View {
+    let icon: String
+    let accentColor: Color
+    let title: String
+    let subtitle: String?
+    let badgeText: String?
+    @Binding var isExpanded: Bool
+    @ViewBuilder let headerTrailing: () -> HeaderTrailing
+    @ViewBuilder let content: () -> Content
+
+    @State private var isHeaderHovered = false
+
+    init(
+        icon: String,
+        accentColor: Color,
+        title: String,
+        subtitle: String? = nil,
+        badgeText: String? = nil,
+        isExpanded: Binding<Bool>,
+        @ViewBuilder headerTrailing: @escaping () -> HeaderTrailing = { EmptyView() },
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.icon = icon
+        self.accentColor = accentColor
+        self.title = title
+        self.subtitle = subtitle
+        self.badgeText = badgeText
+        self._isExpanded = isExpanded
+        self.headerTrailing = headerTrailing
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header Bar
+            HStack(spacing: 12) {
+                // Icon squircle badge
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(accentColor.opacity(0.14))
+                    Image(systemName: icon)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(accentColor)
+                }
+                .frame(width: 32, height: 32)
+
+                // Title + Subtitle
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 8) {
+                        Text(title)
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(.primary)
+
+                        if let badge = badgeText, !badge.isEmpty {
+                            Text(badge)
+                                .font(.system(size: 11, weight: .medium))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 2)
+                                .background(accentColor.opacity(0.12))
+                                .foregroundStyle(accentColor)
+                                .clipShape(Capsule())
+                        }
+                    }
+
+                    if let subtitle = subtitle, !subtitle.isEmpty {
+                        Text(subtitle)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                // Extra trailing controls (e.g. LLM Router Toggle switch)
+                headerTrailing()
+
+                // Chevron icon
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    .padding(.leading, 4)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isHeaderHovered ? Color(nsColor: .quaternaryLabelColor).opacity(0.12) : Color.clear)
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.22)) {
+                    isExpanded.toggle()
+                }
+            }
+            .onHover { hovering in
+                isHeaderHovered = hovering
+            }
+
+            // Body content when expanded
+            if isExpanded {
+                Divider()
+                    .opacity(0.5)
+
+                VStack(alignment: .leading, spacing: 16) {
+                    content()
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .shadow(color: Color.black.opacity(0.04), radius: 3, x: 0, y: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(accentColor.opacity(0.28), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Sub Collapsible Section
+
+struct SubCollapsibleSection<Content: View>: View {
+    let icon: String
+    let accentColor: Color
+    let title: String
+    let description: String?
+    let badgeText: String?
+    @Binding var isExpanded: Bool
+    @ViewBuilder let content: () -> Content
+
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            // Sub-header clickable
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(accentColor)
+                    .frame(width: 18)
+
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.primary)
+
+                if let badge = badgeText, !badge.isEmpty {
+                    Text(badge)
+                        .font(.system(size: 10, weight: .medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(accentColor.opacity(0.1))
+                        .foregroundStyle(accentColor)
+                        .clipShape(Capsule())
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .rotationEffect(.degrees(isExpanded ? 90 : 0))
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color(nsColor: .quaternaryLabelColor).opacity(0.1) : Color.clear)
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            }
+            .onHover { hovering in
+                isHovered = hovering
+            }
+
+            if isExpanded {
+                if let desc = description, !desc.isEmpty {
+                    Text(desc)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                }
+
+                content()
+                    .padding(.horizontal, 2)
+            }
+        }
+    }
+}
+
 // MARK: - Provider Card
 
 struct ProviderCard: View {
@@ -470,10 +735,17 @@ struct ProviderCard: View {
 
     private var providerWebsite: URL? {
         switch provider.id {
-        case "deepseek":  return URL(string: "https://platform.deepseek.com/api_keys")
-        case "ofox":      return URL(string: "https://app.ofox.ai/")
-        case "codebuddy": return URL(string: "https://www.codebuddy.cn/")
-        default:          return nil
+        case "deepseek":    return URL(string: "https://platform.deepseek.com/api_keys")
+        case "ofox":        return URL(string: "https://app.ofox.ai/")
+        case "codebuddy":   return URL(string: "https://www.codebuddy.cn/")
+        case "tokenrouter": return URL(string: "https://www.tokenrouter.com/docs/tokenrouter-feature-guide/")
+        case "openrouter":  return URL(string: "https://openrouter.ai/keys")
+        default:
+            // 本地服务模板 id 形如 "local-ollama-xxxx"，按前缀匹配官网
+            if provider.id.hasPrefix("local-ollama") { return URL(string: "https://ollama.com") }
+            if provider.id.hasPrefix("local-vllm") { return URL(string: "https://docs.vllm.ai") }
+            if provider.id.hasPrefix("local-lmstudio") { return URL(string: "https://lmstudio.ai") }
+            return nil
         }
     }
 
@@ -489,6 +761,7 @@ struct ProviderCard: View {
                     }
                     .iconButtonStyle()
                     .help("打开 \(provider.name) 官网")
+                    .disabled(!provider.enabled)
                 }
                 Spacer()
                 Toggle("", isOn: $provider.enabled)
@@ -496,112 +769,118 @@ struct ProviderCard: View {
                     .labelsHidden()
             }
 
-            if provider.enabled {
-                VStack(spacing: 10) {
-                    HStack(spacing: 8) {
-                        Text("接入点")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 50, alignment: .leading)
-                        TextField("api.provider.com", text: $provider.apiEndpoint)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.caption, design: .monospaced))
-                            .onChange(of: provider.apiEndpoint) { _ in clearTestResult() }
-                    }
-
-                    HStack(spacing: 8) {
-                        Text("API Key")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 50, alignment: .leading)
-                        SecureField("sk-xxxx", text: $provider.apiKey)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.caption, design: .monospaced))
-                            .onChange(of: provider.apiKey) { _ in clearTestResult() }
-                    }
-
-                    HStack(spacing: 8) {
-                        Text("API 路径")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(width: 50, alignment: .leading)
-                        TextField("/v1/chat/completions", text: Binding(
-                            get: { provider.options["api_path"] ?? "" },
-                            set: { newValue in
-                                if newValue.isEmpty {
-                                    provider.options.removeValue(forKey: "api_path")
-                                } else {
-                                    provider.options["api_path"] = newValue
-                                }
-                                clearTestResult()
-                            }
-                        ))
+            // 表单始终渲染，保持卡片大小一致；关闭时整体置灰且不可编辑
+            VStack(spacing: 10) {
+                HStack(spacing: 8) {
+                    Text("接入点")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 50, alignment: .leading)
+                    TextField("api.provider.com", text: $provider.apiEndpoint)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.caption, design: .monospaced))
-                    }
-
-                    HStack(spacing: 8) {
-                        Text(" ")
-                            .frame(width: 50, alignment: .leading)
-                        Toggle("自动同步模型列表（启动时自动从接口获取）", isOn: Binding(
-                            get: { provider.options["auto_models"] == "true" },
-                            set: { newValue in
-                                if newValue {
-                                    provider.options["auto_models"] = "true"
-                                } else {
-                                    provider.options.removeValue(forKey: "auto_models")
-                                }
-                                clearTestResult()
-                            }
-                        ))
-                        .toggleStyle(.switch)
-                        .controlSize(.small)
-                        .font(.system(size: 11))
-                    }
-
-                    // Test connection + fetch models
-                    HStack(spacing: 8) {
-                        Text(" ")
-                            .frame(width: 50, alignment: .leading)
-
-                        Button(action: { testConnection() }) {
-                            if isTesting {
-                                HStack(spacing: 3) {
-                                    ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
-                                    Text("测试中...").font(.system(size: 11, weight: .bold))
-                                }
-                            } else {
-                                ButtonLabel(icon: "play.circle", text: "测试连接")
-                            }
-                        }
-                        .primaryActionStyle()
-                        .disabled(!canTest || isTesting)
-                        .help("验证 API 连通性并获取可用模型列表")
-                    }
-
-                    // Result
-                    if let result = testResult {
-                        HStack(spacing: 6) {
-                            Image(systemName: testOK ? "checkmark.circle.fill" : "xmark.circle.fill")
-                                .font(.system(size: 11))
-                                .foregroundStyle(testOK ? .green : .red)
-                            Text(result)
-                                .font(.system(size: 11))
-                                .foregroundStyle(testOK ? .green : .red)
-                        }
-                    }
+                        .disabled(!provider.enabled)
+                        .onChange(of: provider.apiEndpoint) { _ in clearTestResult() }
                 }
-                .transition(.opacity.combined(with: .move(edge: .top)))
-            } else {
-                Spacer().frame(height: 80)
+
+                HStack(spacing: 8) {
+                    Text("API Key")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 50, alignment: .leading)
+                    SecureField("sk-xxxx", text: $provider.apiKey)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.caption, design: .monospaced))
+                        .disabled(!provider.enabled)
+                        .onChange(of: provider.apiKey) { _ in clearTestResult() }
+                }
+
+                HStack(spacing: 8) {
+                    Text("API 路径")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 50, alignment: .leading)
+                    TextField("/v1/chat/completions", text: Binding(
+                        get: { provider.options["api_path"] ?? "" },
+                        set: { newValue in
+                            if newValue.isEmpty {
+                                provider.options.removeValue(forKey: "api_path")
+                            } else {
+                                provider.options["api_path"] = newValue
+                            }
+                            clearTestResult()
+                        }
+                    ))
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(.caption, design: .monospaced))
+                    .disabled(!provider.enabled)
+                }
+
+                HStack(spacing: 8) {
+                    Text(" ")
+                        .frame(width: 50, alignment: .leading)
+                    Toggle("自动同步可用模型", isOn: Binding(
+                        get: { provider.options["auto_models"] == "true" },
+                        set: { newValue in
+                            if newValue {
+                                provider.options["auto_models"] = "true"
+                            } else {
+                                provider.options.removeValue(forKey: "auto_models")
+                            }
+                            clearTestResult()
+                        }
+                    ))
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .font(.system(size: 11))
+                    .disabled(!provider.enabled)
+                    .help("启动或测试时自动从接口获取最新模型列表")
+                }
+
+                // Test connection + fetch models + inline result
+                HStack(spacing: 8) {
+                    Text(" ")
+                        .frame(width: 50, alignment: .leading)
+
+                    Button(action: { testConnection() }) {
+                        if isTesting {
+                            HStack(spacing: 3) {
+                                ProgressView().scaleEffect(0.7).frame(width: 14, height: 14)
+                                Text("测试中...").font(.system(size: 11, weight: .bold))
+                            }
+                        } else {
+                            ButtonLabel(icon: "play.circle", text: "测试连接")
+                        }
+                    }
+                    .primaryActionStyle()
+                    .disabled(!canTest || !provider.enabled || isTesting)
+                    .help("验证 API 连通性并获取可用模型列表")
+
+                    if let result = testResult {
+                        HStack(spacing: 4) {
+                            Image(systemName: testOK ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                .font(.system(size: 10))
+                            Text(result)
+                                .font(.system(size: 10))
+                                .lineLimit(1)
+                        }
+                        .foregroundStyle(testOK ? .green : .red)
+                    }
+
+                    Spacer()
+                }
             }
+            .opacity(provider.enabled ? 1 : 0.55)
         }
+        .frame(maxWidth: .infinity, minHeight: 220, alignment: .topLeading)
         .padding(16)
-        .background(provider.enabled ? Color.green.opacity(0.04) : Color.gray.opacity(0.02))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(provider.enabled ? Color(nsColor: .textBackgroundColor) : Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        )
         .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(provider.enabled ? Color.green.opacity(0.2) : Color.gray.opacity(0.1), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(provider.enabled ? Color.green.opacity(0.35) : Color(nsColor: .separatorColor).opacity(0.45), lineWidth: 1)
         )
         .animation(.easeInOut(duration: 0.2), value: provider.enabled)
     }
@@ -896,7 +1175,9 @@ struct LLMRouterRuleRow: View {
 
 // MARK: - Preview
 
+#if false
 #Preview {
     ModelRoutingView()
         .environmentObject(LauncherAppState())
 }
+#endif

--- a/tools/probe_provider_models.py
+++ b/tools/probe_provider_models.py
@@ -42,7 +42,11 @@ MODEL_CANDIDATE_GRIDS = {
 
     "hunyuan": [
         "hy3", "hy-3", "hunyuan3", "hunyuan-3", "hy3-chat", "hy3-code", "hy3-pro", "hy3-lite",
-        "hunyuan-chat", "hunyuan-code", "hunyuan-pro", "hunyuan-lite", "hunyuan-standard", "hunyuan-coder"
+        "hunyuan-chat", "hunyuan-code", "hunyuan-pro", "hunyuan-lite", "hunyuan-standard", "hunyuan-coder",
+        "hy4", "hy-4", "hunyuan4", "hunyuan-4", "hy4-chat", "hy4-pro", "hy4-lite", "hy4-turbo",
+        "hy4-preview", "hy4-preview-free", "hy4-preview-lite", "hy4-preview-pro", "hy4-preview-turbo",
+        "hunyuan-4-preview", "hunyuan-4.0", "hunyuan-4.0-pro", "hunyuan-4.0-lite", "hunyuan-4.0-turbo",
+        "hunyuan-t1", "hunyuan-turbo", "hunyuan-turboS", "hunyuan-2.0-instruct"
     ],
 
     "qwen": [


### PR DESCRIPTION
… UI refactor

- CodeBuddy: add hy4-preview to default models (限免版 ID 待确认)
- probe tool: extend hunyuan candidate grid with hy4 variants
- Local model services: Ollama / vLLM / LM Studio builtin provider cards (auto_models, dedup by id prefix on config load)
- SSL_CERT_FILE: ensureCombinedCABundle now returns path; only injected when a valid combined bundle exists (Go falls back to OS trust store otherwise)
- OpenRouter/TokenRouter: new default providers + metadata-aware model filtering (drop non-text/embed/moderation, order flagship -> free -> other)
- Model routing UI: merge provider & rule sections into collapsible cards (CollapsibleCard / SubCollapsibleSection), scrollable provider grid, ProviderCard form always rendered (disabled when off)
- gitignore: .derived_data/