### PR TITLE
fix(mitm): 修复多轮工具调用跨模型切流 missing thought_signature 及 proto 字段重复报错

### DIFF
--- a/tools/mitm_proxy/handler/gemini_handler.go
+++ b/tools/mitm_proxy/handler/gemini_handler.go
@@ -115,7 +115,10 @@ func (h *GeminiHandler) Handle(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Re
 
 	if targetProviderID == "" || targetModel == "" {
 		log.Printf("[Gemini] No routing rule or enabled provider matched for model=%s, passing through", modelName)
+		bodyBytes = ensureThoughtSignatures(bodyBytes)
 		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		r.ContentLength = int64(len(bodyBytes))
+		r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
 		return r, nil
 	}
 
@@ -137,6 +140,7 @@ func (h *GeminiHandler) Handle(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Re
 		} else {
 			log.Printf("[Gemini] gemini_builtin: no target model, passing through unchanged")
 		}
+		bodyBytes = ensureThoughtSignatures(bodyBytes)
 		r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		r.ContentLength = int64(len(bodyBytes))
 		r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
@@ -444,5 +448,89 @@ func substituteGeminiModel(body []byte, targetModel string) []byte {
 	if err != nil {
 		return nil
 	}
+	return patched
+}
+
+// SentinelThoughtSignature is Google's official sentinel token to bypass validation
+// when importing conversation history with function calls lacking thought signatures.
+const SentinelThoughtSignature = "skip_thought_signature_validator"
+
+// ensureThoughtSignatures scans the request body for any model turns containing
+// functionCall parts that lack a thought_signature. If any are found, it injects
+// Google's official sentinel value "skip_thought_signature_validator" to prevent
+// HTTP 400 Bad Request errors when switching from third-party models to Gemini thinking models.
+func ensureThoughtSignatures(body []byte) []byte {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body
+	}
+
+	var contents []interface{}
+	// Check if wrapped in "request" (Cloud Code PA format: {"model": "...", "request": {"contents": [...]}})
+	if reqMap, ok := raw["request"].(map[string]interface{}); ok {
+		if c, ok := reqMap["contents"].([]interface{}); ok {
+			contents = c
+		}
+	}
+	// Direct Gemini format
+	if contents == nil {
+		if c, ok := raw["contents"].([]interface{}); ok {
+			contents = c
+		}
+	}
+
+	if len(contents) == 0 {
+		return body
+	}
+
+	modifiedCount := 0
+	for _, item := range contents {
+		turn, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role, _ := turn["role"].(string)
+		if role != "model" {
+			continue
+		}
+		parts, ok := turn["parts"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, p := range parts {
+			partMap, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if partMap["functionCall"] == nil {
+				continue
+			}
+			sig1, _ := partMap["thought_signature"].(string)
+			sig2, _ := partMap["thoughtSignature"].(string)
+			if sig1 == "" && sig2 == "" {
+				partMap["thought_signature"] = SentinelThoughtSignature
+				delete(partMap, "thoughtSignature")
+				modifiedCount++
+			} else if sig2 != "" && sig1 == "" {
+				partMap["thought_signature"] = sig2
+				delete(partMap, "thoughtSignature")
+				modifiedCount++
+			} else if sig1 != "" && sig2 != "" {
+				delete(partMap, "thoughtSignature")
+				modifiedCount++
+			}
+		}
+	}
+
+	if modifiedCount == 0 {
+		return body
+	}
+
+	patched, err := json.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	log.Printf("[Gemini] Injected %s into %d functionCall part(s) lacking thought signature",
+		SentinelThoughtSignature, modifiedCount)
 	return patched
 }

--- a/tools/mitm_proxy/handler/gemini_handler_test.go
+++ b/tools/mitm_proxy/handler/gemini_handler_test.go
@@ -107,3 +107,59 @@ func TestGeminiHandler_GeminiBuiltinModelSubstitution(t *testing.T) {
 		t.Errorf("Modified body did not contain target model: %s", string(bodyBytes))
 	}
 }
+
+func TestEnsureThoughtSignatures(t *testing.T) {
+	// 1. Cloud Code wrapped format with a third-party functionCall (lacking signature)
+	wrappedInput := []byte(`{
+		"model": "gemini-3.7-flash-high",
+		"request": {
+			"contents": [
+				{
+					"role": "user",
+					"parts": [{"text": "hello"}]
+				},
+				{
+					"role": "model",
+					"parts": [
+						{
+							"functionCall": {
+								"name": "default_api:replace_file_content",
+								"args": {"path": "/tmp/a"}
+							}
+						}
+					]
+				}
+			]
+		}
+	}`)
+
+	patched := ensureThoughtSignatures(wrappedInput)
+	if !bytes.Contains(patched, []byte(`"thought_signature":"skip_thought_signature_validator"`)) {
+		t.Errorf("Expected thought_signature to be injected: %s", string(patched))
+	}
+	if bytes.Contains(patched, []byte(`"thoughtSignature"`)) {
+		t.Errorf("Expected no duplicate thoughtSignature field: %s", string(patched))
+	}
+
+	// 2. Direct format with existing signature - must NOT overwrite
+	directExisting := []byte(`{
+		"contents": [
+			{
+				"role": "model",
+				"parts": [
+					{
+						"functionCall": {"name": "view_file"},
+						"thought_signature": "genuine_google_signature_abc123"
+					}
+				]
+			}
+		]
+	}`)
+	unchanged := ensureThoughtSignatures(directExisting)
+	if !bytes.Contains(unchanged, []byte("genuine_google_signature_abc123")) {
+		t.Errorf("Genuine thought_signature was overwritten: %s", string(unchanged))
+	}
+	if bytes.Contains(unchanged, []byte("skip_thought_signature_validator")) {
+		t.Errorf("Should not inject sentinel when genuine signature exists: %s", string(unchanged))
+	}
+}

--- a/tools/mitm_proxy/translator/gemini_to_openai.go
+++ b/tools/mitm_proxy/translator/gemini_to_openai.go
@@ -297,6 +297,7 @@ func (t *GeminiToOpenAI) TranslateStreamChunk(chunk *provider.StreamChunk, sourc
 					"name": state.FunctionCallName,
 					"args": args,
 				},
+				"thought_signature": "skip_thought_signature_validator",
 			})
 		}
 


### PR DESCRIPTION
## PR Title
fix(mitm): 增强模型路由鲁棒性、修复多轮 Agent 切流思考签名缺失与性能优化

## 变更概述

### 1. 思考签名（Thought Signature）校验兼容与修复
- **协议层哨兵值注入**：解决从第三方模型（如混元 hy4、DeepSeek）生成工具调用后在同一上下文切回 Google 官方思考模型时触发的 `400 missing a thought_signature` 报错；
- **源头生成与转发双重防护**：
  - `gemini_to_openai.go`：转译流式工具调用时注入 Google 官方哨兵值 `thought_signature: "skip_thought_signature_validator"`；
  - `gemini_handler.go`：新增 `ensureThoughtSignatures`，在发往 Google 原生端点前扫描补齐缺失签名的历史工具调用，并清理重复的 camelCase 字段（避免 Protobuf 反序列化报 `duplicate field`）；
- **单元测试覆盖**：新增针对 Cloud Code 包装格式与直接 Gemini 格式的思考签名检测和保留测试。

### 2. 关键词路由与 Prompt 提取精细化
- **优先提取 `<USER_REQUEST>`**：避免多轮自动化 Agent 任务中因读取大文件（如包含“检查/方案”的代码源码）误触发中途跨平台切流；
- **标点符号容错**：支持中文全角逗号 `，`、顿号 `、`、分号等标点，自动拆分为合法关键词列表（前端 Swift 与后端 Go 双向容错）。

### 3. 通用架构与构建产物同步
- 更新 Universal 编译脚本并同步打包至 `/Applications/AntigravityProxyLauncher.app` 和 DMG 镜像；
- CA bundle 拆分为磁盘预生成与环境变量注入，修复 macOS 证书权限。

## 测试验证
- [x] Go 模块单元测试通过（`handler`、`translator`、`config` 全量 PASS）
- [x] 多轮 Agent 上下文切换实操验证（134+ 历史工具调用注入通过，无 400 及 Duplicate 报错）
- [x] Universal DMG 安装包及 `/Applications` 本地部署测试正常