### PR TITLE
fix(gemini): 更新关键词路由 Gemini 3.8 Flash 模型并移除废弃旧模型

### DIFF
--- a/launcher/Sources/Models/ModelRoutingConfig.swift
+++ b/launcher/Sources/Models/ModelRoutingConfig.swift
@@ -18,10 +18,15 @@ struct GeminiBuiltinModel: Identifiable, Hashable {
     }
 }
 
-/// 内置 Gemini 模型列表（2026-08-18 从 daily-cloudcode-pa.googleapis.com fetchAvailableModels 抓取的真实可用 ID）
-/// 注意：后端要求带后缀的 ID（-high/-low/-medium/-tiered/-agent 等），裸 ID（如 gemini-3.6-flash）会返回 404。
+/// 内置 Gemini 模型列表（2026-09-04 从 daily-cloudcode-pa.googleapis.com fetchAvailableModels 抓取的真实可用 ID，
+/// 其中包含 2026-09-02 新发布的 Gemini 3.8 Flash：gemini-3.8-flash-{high,low,medium,tiered}）
+/// 注意：后端要求带后缀的 ID（-high/-low/-medium/-tiered/-agent 等），裸 ID（如 gemini-3.8-flash）会返回 404。
 /// 显示名直接取自 fetchAvailableModels 响应的 display name（个别为 "-" 的 tiered 模型按同族命名）。
 let GeminiBuiltinModels: [GeminiBuiltinModel] = [
+    GeminiBuiltinModel("gemini-3.8-flash-high", "Gemini 3.8 Flash (High)"),
+    GeminiBuiltinModel("gemini-3.8-flash-low", "Gemini 3.8 Flash (Low)"),
+    GeminiBuiltinModel("gemini-3.8-flash-medium", "Gemini 3.8 Flash (Medium)"),
+    GeminiBuiltinModel("gemini-3.8-flash-tiered", "Gemini 3.8 Flash (Tiered)"),
     GeminiBuiltinModel("gemini-3.7-flash-high", "Gemini 3.7 Flash (High)"),
     GeminiBuiltinModel("gemini-3.7-flash-low", "Gemini 3.7 Flash (Low)"),
     GeminiBuiltinModel("gemini-3.7-flash-medium", "Gemini 3.7 Flash (Medium)"),
@@ -30,19 +35,8 @@ let GeminiBuiltinModels: [GeminiBuiltinModel] = [
     GeminiBuiltinModel("gemini-3.6-flash-low", "Gemini 3.6 Flash (Low)"),
     GeminiBuiltinModel("gemini-3.6-flash-medium", "Gemini 3.6 Flash (Medium)"),
     GeminiBuiltinModel("gemini-3.6-flash-tiered", "Gemini 3.6 Flash (Tiered)"),
-    GeminiBuiltinModel("gemini-3.5-flash-extra-low", "Gemini 3.5 Flash (Low)"),
-    GeminiBuiltinModel("gemini-3.5-flash-low", "Gemini 3.5 Flash (Medium)"),
-    GeminiBuiltinModel("gemini-3-flash-agent", "Gemini 3.5 Flash (High)"),
-    GeminiBuiltinModel("gemini-3-flash", "Gemini 3 Flash"),
     GeminiBuiltinModel("gemini-3.1-pro-high", "Gemini 3.1 Pro (High)"),
     GeminiBuiltinModel("gemini-3.1-pro-low", "Gemini 3.1 Pro (Low)"),
-    GeminiBuiltinModel("gemini-pro-agent", "Gemini 3.1 Pro (High)"),
-    GeminiBuiltinModel("gemini-3.1-flash-image", "Gemini 3.1 Flash Image"),
-    GeminiBuiltinModel("gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite"),
-    GeminiBuiltinModel("gemini-2.5-flash", "Gemini 3.1 Flash Lite"),
-    GeminiBuiltinModel("gemini-2.5-flash-lite", "Gemini 3.1 Flash Lite"),
-    GeminiBuiltinModel("gemini-2.5-flash-thinking", "Gemini 3.1 Flash Lite"),
-    GeminiBuiltinModel("gemini-2.5-pro", "Gemini 2.5 Pro"),
 ]
 
 struct ModelRoutingConfig: Codable, Equatable {

--- a/launcher/Sources/Services/PatchService.swift
+++ b/launcher/Sources/Services/PatchService.swift
@@ -230,8 +230,18 @@ final class PatchService {
                 esac
             done
             SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+            # Clean up terminal proxy environment variables that conflict with dylib tun
+            unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy
+
             export DYLD_INSERT_LIBRARIES="$SCRIPT_DIR/libAntigravityTun.dylib"
             export ANTIGRAVITY_CONFIG="$HOME/.config/antigravity/proxy_config.json"
+            # Trust MITM proxy CA bundle for Go binaries and Node.js
+            if [ -f "$HOME/.config/antigravity/combined_ca.pem" ]; then
+                export SSL_CERT_FILE="$HOME/.config/antigravity/combined_ca.pem"
+            fi
+            if [ -f "$HOME/.config/antigravity/goproxy_ca.pem" ]; then
+                export NODE_EXTRA_CA_CERTS="$HOME/.config/antigravity/goproxy_ca.pem"
+            fi
             # Redirect dylib logs to file to keep stderr clean for CLI output
             export ANTIGRAVITY_LOG_FILE=1
             export ANTIGRAVITY_LOG_PATH="$HOME/.config/antigravity/antigravity_proxy.$$.log"


### PR DESCRIPTION
- GeminiBuiltinModels 新增 Gemini 3.8 Flash (High/Low/Medium/Tiered)， 依据 daily-cloudcode-pa 实时 fetchAvailableModels 日志补全真实可用 ID
- 移除已废弃模型：gemini-pro-agent / gemini-3.1-flash-* / gemini-2.5-* / gemini-3.5-flash-* / gemini-3-flash* 等共 11 项
- PatchService CLI 包装脚本：启动时清理终端代理环境变量 (HTTP_PROXY 等)， 避免与 libAntigravityTun 冲突；并注入 SSL_CERT_FILE / NODE_EXTRA_CA_CERTS 以信任本地 MITM 代理根证书